### PR TITLE
Add support for setting results workers by config

### DIFF
--- a/_config/config_example.toml
+++ b/_config/config_example.toml
@@ -15,6 +15,7 @@ endpoint = "https://vulcan-persistence-dev.example.com"
 
 [results]
 endpoint = "https://vulcan-results-dev.example.com"
+workers = 5
 
 [proxy]
 endpoint = "https://insights-dev.vulcan.example.com"

--- a/config/config.go
+++ b/config/config.go
@@ -6,6 +6,10 @@ import (
 	"github.com/BurntSushi/toml"
 )
 
+const (
+	defResultsWorkers = 5
+)
+
 type Config struct {
 	Analytics   analytics         `toml:"analytics"`
 	S3          s3Config          `toml:"s3"`
@@ -35,6 +39,7 @@ type persistenceConfig struct {
 
 type resultsConfig struct {
 	Endpoint string `toml:"endpoint"`
+	Workers  int    `toml:"workers"`
 }
 
 type proxy struct {
@@ -68,6 +73,11 @@ func ReadConfig(configFile string) (Config, error) {
 	var config Config
 	if _, err := toml.Decode(string(configData), &config); err != nil {
 		return Config{}, err
+	}
+
+	// Parse default config values.
+	if config.Results.Workers == 0 {
+		config.Results.Workers = defResultsWorkers
 	}
 
 	return config, nil


### PR DESCRIPTION
This PR removes the hard coded number of workers to use when retrieving checks information from vulcan-results and adds support for defining it by configuration with a default value equal to the previously hard coded one in case it's not specified.