### PR TITLE
Gen report from check

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ go install ./...
 
 
 
-It works by supporting two scenarios:
+It works by supporting three scenarios:
 
 1. Generate and optionally upload a report.
 
@@ -40,3 +40,13 @@ It works by supporting two scenarios:
     vulcan-security-overview -regen .localtest/test-report.json -resources _resources/ -presources _public_resources/ --assetsurl https://example.com/assets  -output .localtest/reports
 
     ```
+3. Generate a full report from a file with a check report.
+
+   This scenario is useful when adjusting the output of a check.
+   This command takes, apart from the config file, a parameter pointing to a file that contains a check report.
+   It generates and uploads to s3 a full report with the findings of that check.
+
+   Example of the command:
+   ```
+    vulcan-security-overview -config "security-overview.toml" -check check_report.json
+   ```

--- a/cmd/vulcan-security-overview/main.go
+++ b/cmd/vulcan-security-overview/main.go
@@ -27,7 +27,7 @@ Takes a path to the json file. for instance ./report.json`)
 	detailsURL = flag.String("detailsurl", "", "[required with regen] specifies the base url of the details")
 	output     = flag.String("output", "", "[required with regen] specifies the directory to save regenerated report")
 	check      = flag.String("check", "", `generates the security overview for test pourposes from a single check report stored in 
-	a file. The only required flag is the config param`)
+a file. The only other required flag is -config. Example: vulcan-security-overview -config ".security-overview.toml" -check check_report.json`)
 )
 
 func checkParams() bool {

--- a/report.go
+++ b/report.go
@@ -140,6 +140,81 @@ func (d *DetailedReport) GenerateLocalFiles() error {
 	return nil
 }
 
+// GenerateLocalFilesFromCheck grabs the check report stored in a file
+// and generates the html report using that unique check report.
+func (d *DetailedReport) GenerateLocalFilesFromCheck(path string) error {
+
+	reportData, err := vulcan.GetReportDataFromFile(d.conf, d.scanID, path)
+	if err != nil {
+		return err
+	}
+	// NOTE: Grouping is done using vulcan-groupie in the vulcan package.
+	// reportData = groupVulnerabilitiesByTextSimilarity(reportData)
+
+	buf, err := json.Marshal(reportData)
+	if err != nil {
+		return err
+	}
+
+	ioutil.WriteFile(d.teamName+".json", buf, 0600)
+
+	// Assemble the folder name. The format is:	hex(sha256(teamName))/YYYY-MM-DD
+	// The idea behind this is that if we use teams names as folder names, then
+	// it would be easy to predict in which folders the reports are stored for
+	// each team
+	sha := fmt.Sprintf("%x", sha256.Sum256([]byte(d.teamName)))
+	d.folder = filepath.Join(sha, reportData.Date)
+
+	// Remove previously generated files and folders and then recreate them.
+	err = d.cleanLocalFolders()
+	if err != nil {
+		return err
+	}
+
+	// Generate files for the Overview. The files will be stored in this way:
+	// <scan-id>/
+	//	  '
+	//    '--<scan-id>-overview.html
+	//	  '
+	//    '--<public-bucket>/
+	//	         '
+	//           '--<hex(sha256(teamName))>/
+	//	                '
+	//                  '--<YYYY-MM-DD>/
+	//                         '
+	//                         '--<Most Vulnerable Assets>.png
+	//                         '
+	//                         '--<Impact Distribution>.png
+	d.Email, err = report.GenerateOverview(d.conf, d.awsConfig, d.conf.General.ResourcesPath, d.folder, reportData, d.teamName, d.teamID, d.scanID)
+	if err != nil {
+		return err
+	}
+
+	// Generate files for the Full Report. The files will be stored in this way:
+	// <scan-id>/
+	//    '
+	//    '--<private-bucket>/
+	//           '
+	//           '--<hex(sha256(teamName))>/
+	//                  '
+	//                  '--<YYYY-MM-DD>/
+	//                         '
+	//                         '--<scan-id>-full-report.html
+	//                         '
+	//                         '--<script>.js
+	//
+	// The result will be the the URL in which the Full Report will be available.
+	// The Overview HTML will be generated pointing to this link.
+	d.URL, err = report.GenerateFullReport(d.conf, d.awsConfig, d.conf.General.ResourcesPath, d.folder, reportData, d.teamName)
+	if err != nil {
+		return err
+	}
+
+	d.Risk = int(reportData.Risk)
+
+	return nil
+}
+
 func (d *DetailedReport) cleanLocalFolders() error {
 	err := os.RemoveAll(filepath.Join(d.conf.General.LocalTempDir, d.scanID))
 	if err != nil {

--- a/report.go
+++ b/report.go
@@ -171,25 +171,6 @@ func (d *DetailedReport) GenerateLocalFilesFromCheck(path string) error {
 		return err
 	}
 
-	// Generate files for the Overview. The files will be stored in this way:
-	// <scan-id>/
-	//	  '
-	//    '--<scan-id>-overview.html
-	//	  '
-	//    '--<public-bucket>/
-	//	         '
-	//           '--<hex(sha256(teamName))>/
-	//	                '
-	//                  '--<YYYY-MM-DD>/
-	//                         '
-	//                         '--<Most Vulnerable Assets>.png
-	//                         '
-	//                         '--<Impact Distribution>.png
-	d.Email, err = report.GenerateOverview(d.conf, d.awsConfig, d.conf.General.ResourcesPath, d.folder, reportData, d.teamName, d.teamID, d.scanID)
-	if err != nil {
-		return err
-	}
-
 	// Generate files for the Full Report. The files will be stored in this way:
 	// <scan-id>/
 	//    '

--- a/vulcan/vulcan.go
+++ b/vulcan/vulcan.go
@@ -126,7 +126,7 @@ func GetReportDataFromFile(conf config.Config, scanID, path string) (*ReportData
 	rp := &ReportData{ScanID: scanID, countChecks: 0, groupie: g}
 	date := time.Now().Format("2006-01-02")
 	rp.Date = date
-	log.Printf("Getting reports from results api...")
+	log.Printf("Getting reports from results json file...")
 	rp.Reports = []vulcanreport.Report{}
 
 	content, err := ioutil.ReadFile(path)

--- a/vulcan/vulcan.go
+++ b/vulcan/vulcan.go
@@ -2,8 +2,11 @@ package vulcan
 
 import (
 	"context"
+	"encoding/json"
+	"io/ioutil"
 	"log"
 	"sort"
+	"time"
 
 	"github.com/adevinta/security-overview/config"
 	"github.com/adevinta/security-overview/vulcan/persistence"
@@ -88,6 +91,54 @@ func GetReportData(conf config.Config, scanID string) (*ReportData, error) {
 	// This waits for all workers to be finished.
 	rp.workerWG.Wait()
 
+	rp.setRisk()
+	rp.setActionRequired()
+	rp.setAssets()
+	rp.setChecktypes()
+	rp.setVulnerabilitiesPerImpact()
+	rp.setVulnerabilitiesPerAssets()
+	rp.setTopVulnerabilities()
+	rp.setNumberOfVulnerableAssets()
+	rp.setAllVulnerabilities()
+
+	// Update grouping database with scan before retrieving groups.
+	if err := g.UpdateFromScan(scanID, date, rp.Reports); err != nil {
+		return nil, err
+	}
+
+	if err := rp.setGroups(); err != nil {
+		return nil, err
+	}
+
+	if err := rp.setGroupsPerAsset(); err != nil {
+		return nil, err
+	}
+
+	return rp, nil
+}
+
+// GetReportDataFromFile extracts information about a check report
+// stored in file.
+func GetReportDataFromFile(conf config.Config, scanID, path string) (*ReportData, error) {
+	m := db.NewMemDB()
+	g := groupie.New(m)
+
+	rp := &ReportData{ScanID: scanID, countChecks: 0, groupie: g}
+	date := time.Now().Format("2006-01-02")
+	rp.Date = date
+	log.Printf("Getting reports from results api...")
+	rp.Reports = []vulcanreport.Report{}
+
+	content, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var r vulcanreport.Report
+	err = json.Unmarshal(content, &r)
+	if err != nil {
+		return nil, err
+	}
+	rp.Reports = append(rp.Reports, r)
 	rp.setRisk()
 	rp.setActionRequired()
 	rp.setAssets()


### PR DESCRIPTION
This PR adds a new functionality in the vulcan-security-overview that allows to generate a full report from the output generated by a check.
The functionality is intended to be used while developing a check locally, so it is easy to see how the vulnerabilities generated by the check look in the full report.
This is an example of the command using the new functionality:
```

vulcan-security-overview -config security-overview.toml -check check_report.json 
```