### PR TITLE
Adapt to v2 of vulcan core

### DIFF
--- a/vulcan/persistence/types.go
+++ b/vulcan/persistence/types.go
@@ -23,9 +23,9 @@ type Checks struct {
 
 //Check represents an individual check from Checks
 type Check struct {
-	ID            string  `json:"id"`
-	Target        string  `json:"target"`
-	Status        string  `json:"status"`
-	Score         float32 `json:"score"`
-	CheckTypeName string  `json:"checktype_name"`
+	ID            string `json:"id"`
+	Target        string `json:"target"`
+	Status        string `json:"status"`
+	Report        string `json:"report"`
+	CheckTypeName string `json:"checktype_name"`
 }

--- a/vulcan/results/api.go
+++ b/vulcan/results/api.go
@@ -1,18 +1,22 @@
 package results
 
 import (
-	"fmt"
 	"io/ioutil"
 	"net/http"
+	"net/url"
 
-	"github.com/adevinta/vulcan-report"
+	report "github.com/adevinta/vulcan-report"
 )
 
 //GetReport retrieves a report stored on vulcan results
-func GetReport(baseEndpoint, date, scanID, checkID string) (*report.Report, error) {
-	endpoint := baseEndpoint + fmt.Sprintf("/v1/reports/dt=%s/scan=%s/%s.json", date, scanID, checkID)
-	//fmt.Printf("Getting results for:%s", endpoint)
-	resp, err := http.Get(endpoint)
+func GetReport(baseEndpoint, rurl string) (*report.Report, error) {
+	u, err := url.Parse(baseEndpoint)
+	if err != nil {
+		return nil, err
+	}
+	reportURL, err := url.Parse(rurl)
+	u.Path = reportURL.Path
+	resp, err := http.Get(u.String())
 	if err != nil {
 		return nil, err
 	}

--- a/vulcan/types.go
+++ b/vulcan/types.go
@@ -3,6 +3,7 @@ package vulcan
 import (
 	"sync"
 
+	"github.com/adevinta/security-overview/vulcan/persistence"
 	"github.com/adevinta/vulcan-groupie/pkg/groupie"
 	"github.com/adevinta/vulcan-groupie/pkg/models"
 	vulcanreport "github.com/adevinta/vulcan-report"
@@ -30,7 +31,7 @@ type ReportData struct {
 	workerWG    sync.WaitGroup
 	countChecks int
 	mu          sync.RWMutex
-	chanChecks  chan string
+	chanChecks  chan persistence.Check
 	groupie     *groupie.Groupie
 }
 


### PR DESCRIPTION
This PR makes the security overview compatible with the v2 version of the vulcan core. The modifications just remove all the assumptions the overview was making about how the checks of a scan are stored in s3. Now it just relays in the url specified by the vulcan core for each check report. Note that in order to make it easier to run locally, it does not use the hostname and schema specified in the check's report url but uses the schema and hostname specified in the config for the results services. 
For instance if the report for a check is in https://results.example.com/v1/check1/report.json and the config section for the results service is: 
```
[results]
endpoint = "http://vulcan-results.example.com/" 
````
The url that the security overview will use in order to get the report for the check will be:
http://vulcan-results.example.com/v1/check1/report.json